### PR TITLE
Allow usage of Ansible module group defaults

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,16 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_cloudmanager:
+    - na_cloudmanager_aggregate
+    - na_cloudmanager_cifs_server
+    - na_cloudmanager_connector_aws
+    - na_cloudmanager_connector_azure
+    - na_cloudmanager_connector_gcp
+    - na_cloudmanager_cvo_aws
+    - na_cloudmanager_cvo_azure
+    - na_cloudmanager_cvo_gcp
+    - na_cloudmanager_info
+    - na_cloudmanager_nss_account
+    - na_cloudmanager_snapmirror
+    - na_cloudmanager_volume


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.cloudmanager
  module_defaults:
    group/netapp.ontap.netapp_cloudmanager:
       # common options goes here
```

