### PR TITLE
README: Add Communication section with Forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ collections:
 https://docs.ansible.com/ansible/devel/collections/netapp/cloudmanager/
 
 # Need help
-
 Join our [Discord](https://discord.gg/NetApp) and look for our #ansible channel.
 
 * Join the Ansible forum:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ collections:
 https://docs.ansible.com/ansible/devel/collections/netapp/cloudmanager/
 
 # Need help
+
 Join our [Discord](https://discord.gg/NetApp) and look for our #ansible channel.
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [Posts tagged with 'netapp'](https://forum.ansible.com/tag/netapp): subscribe to participate in collection-related conversations.
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
 
 # Code of Conduct
 This collection follows the [Ansible project's Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

- I've created the `netapp` forum tag. It's not a must for maintainers to be subscribed but please consider it
- If you have other forum tags related to the collection, please update corresponding lines by suggesting changes to the PR.
- Presence in the forum will soon likely become a part of the Collection inclusion requirements.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md
